### PR TITLE
Poverty bug fix

### DIFF
--- a/policyengine-client/package.json
+++ b/policyengine-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "policyengine-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "dependencies": {
     "@ant-design/icons": "^4.7.0",
     "@emotion/react": "^11.5.0",

--- a/policyengine/countries/country.py
+++ b/policyengine/countries/country.py
@@ -64,6 +64,7 @@ class PolicyEngineCountry:
         )
 
         self.baseline.simulation.trace = True
+        self.default_year = 2021
         self.baseline.calc("net_income")
 
         self.policyengine_parameters = get_PE_parameters(
@@ -100,6 +101,7 @@ class PolicyEngineCountry:
             (self.default_reform, reform), dataset=self.default_dataset
         )
         sim.simulation.trace = True
+        self.default_year = 2021
         sim.calc("net_income")
         return sim
 

--- a/policyengine/impact/population/metrics.py
+++ b/policyengine/impact/population/metrics.py
@@ -16,7 +16,7 @@ def poverty_rate(
     population: str,
     config: Type[PolicyEngineResultsConfig],
 ) -> float:
-    return sim.calc(config.in_poverty_variable, map_to="person", period=2021)[
+    return sim.calc(config.in_poverty_variable, map_to="person")[
         sim.calc(population) > 0
     ].mean()
 

--- a/policyengine/server.py
+++ b/policyengine/server.py
@@ -15,7 +15,7 @@ from policyengine.countries import UK, PolicyEngineCountry
 
 
 class PolicyEngine:
-    version: str = "1.1.0"
+    version: str = "1.1.1"
     cache_bucket_name: str = "uk-policy-engine.appspot.com"
     countries: Tuple[Type[PolicyEngineCountry]] = (UK,)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 setup(
     name="PolicyEngine",
-    version="1.1.0",
+    version="1.1.1",
     author="PolicyEngine",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/policyengine/policyengine",


### PR DESCRIPTION
# Bug fix: Poverty chart rates slightly out of sync with takeaway

I think this was caused by the chart calculating poverty rates a year ahead of the takeaway. I've fixed it by forcing all calculations to use the `default_year` argument rather than setting explicitly.

### Status
- [ ] Cosmetic change
  - [ ] Screenshots attached
- [ ] Back-end change
  - [ ] Unintuitive logic commented
- [ ] Version change
  - [ ] Major
  - [ ] Minor
  - [ ] Patch

### Issues fixed