### PR TITLE
Auto-generate summary field

### DIFF
--- a/policyengine-client/src/common/header.jsx
+++ b/policyengine-client/src/common/header.jsx
@@ -107,7 +107,7 @@ function MainNavigation(props) {
 
 export function Title(props) {
 	const tags = props.beta ? [<Tag key="beta" color="#002766">BETA</Tag>] : null;
-	const title = <Image src={MainLogo} preview={false} height={50} width={80} style={{padding: 0, margin: 0}} />
+	const title = <a href="/"><Image src={MainLogo} preview={false} height={50} width={80} style={{padding: 0, margin: 0}} /></a>
 	return (
 		<div style={{minWidth: 300}}>
 			<div className="d-none d-lg-flex align-items-center ">

--- a/policyengine/server.py
+++ b/policyengine/server.py
@@ -15,7 +15,7 @@ from policyengine.countries import UK, PolicyEngineCountry
 
 
 class PolicyEngine:
-    version: str = "1.1.3"
+    version: str = "1.1.4"
     cache_bucket_name: str = "uk-policy-engine.appspot.com"
     countries: Tuple[Type[PolicyEngineCountry]] = (UK,)
 

--- a/policyengine/utils/reforms.py
+++ b/policyengine/utils/reforms.py
@@ -110,6 +110,21 @@ def add_parameter_file(path: str) -> Reform:
     return reform
 
 
+def summary_from_metadata(metadata: dict) -> str:
+    """Generates a summary from parameter metadata.
+
+    Args:
+        metadata (dict): The parameter metadata.
+
+    Returns:
+        str: The summary.
+    """
+    if metadata["type"] == "abolish":
+        return f"Abolish {metadata['title']}"
+    else:
+        return f"Change the {metadata['title']} to @"
+
+
 def get_PE_parameters(system: TaxBenefitSystem) -> Dict[str, dict]:
     """Extracts PolicyEngine parameters from OpenFisca parameter metadata.
 
@@ -145,7 +160,6 @@ def get_PE_parameters(system: TaxBenefitSystem) -> Dict[str, dict]:
             description=meta["description"],
             default=p(CURRENT_INSTANT),
             value=p(CURRENT_INSTANT),
-            summary=meta["summary"],
         )
         default_values = dict(
             min=0,
@@ -158,6 +172,7 @@ def get_PE_parameters(system: TaxBenefitSystem) -> Dict[str, dict]:
                 param[key] = meta[key]
             else:
                 param[key] = value
+        param["summary"] = summary_from_metadata(param)
         parameter_metadata[param["short_name"]] = param
     return parameter_metadata
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 setup(
     name="PolicyEngine",
-    version="1.1.7",
+    version="1.1.8",
     author="PolicyEngine",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/policyengine/policyengine",


### PR DESCRIPTION
# Bug fix: Auto-generate summary field

Fixes an issue causing the decile chart colouring to malfunction (because multiple provisions had the same summary field).

### Status
- [x] Cosmetic change
  - [x] Screenshots attached
- [x] Back-end change
  - [x] Unintuitive logic commented
- [x] Version change
  - [ ] Major
  - [ ] Minor
  - [x] Patch

### Issues fixed
Fixes #170 
Fixes #78 (summary metadata fields can be safely deleted in openfisca-uk after this - they are now ignored)

### Screenshots

#### Fixed decile chart for #170
![image](https://user-images.githubusercontent.com/35577657/141860192-0ae262ae-d268-40c6-8e7c-3bac77aea17f.png)
