### PR TITLE
Fix deployment error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ pathlib
 jupyter-book>=0.11.1
 sphinxcontrib-bibtex>=1.0.0
 synthimpute>=0.1.0
-OpenFisca-US>=0.0.3,<0.1.0
+OpenFisca-US==0.1.0


### PR DESCRIPTION
The `requirements.txt` didn't match `setup.py` in its requirement for openfisca-us.