### PR TITLE
Add openfisca-us-data to deployment environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,13 @@ openfisca_uk_data:
 	openfisca-uk-data frs_was_imp download 2019
 	cp -r openfisca-uk-data/openfisca_uk_data/ openfisca_uk_data
 	rm -rf openfisca-uk-data
-deploy: openfisca_uk_data openfisca_uk test
+openfisca_us_data:
+	git clone https://github.com/ubicenter/openfisca-us-data --depth 1
+	cd openfisca-us-data; pip install -e .
+	openfisca-us-data cps generate 2020
+	cp -r openfisca-us-data/openfisca_us_data/ openfisca_us_data
+	rm -rf openfisca-us-data
+deploy: openfisca_uk_data openfisca_us_data openfisca_uk test
 	rm -rf policyengine/static
 	cd policyengine-client; npm run build
 	cp -r policyengine-client/build policyengine/static

--- a/app.yaml
+++ b/app.yaml
@@ -3,7 +3,7 @@ env: flex
 resources:
   cpu: 1
   memory_gb: 6
-  disk_size_gb: 10
+  disk_size_gb: 16
 automatic_scaling:
   min_num_instances: 1
   max_num_instances: 4

--- a/app.yaml
+++ b/app.yaml
@@ -3,7 +3,7 @@ env: flex
 resources:
   cpu: 1
   memory_gb: 6
-  disk_size_gb: 16
+  disk_size_gb: 20
 automatic_scaling:
   min_num_instances: 1
   max_num_instances: 4


### PR DESCRIPTION
Attempts to fix the failing US build - the error was from a HDF5 "back error trace" when generating the `RawCPS` dataset. So I've gone with the UK approach and added the actual module `openfisca_us_data` to the deployment environment, after downloading the dataset before deployment.