### PR TITLE
Add UK /calculate endpoint

### DIFF
--- a/policyengine/countries/uk/__init__.py
+++ b/policyengine/countries/uk/__init__.py
@@ -1,5 +1,9 @@
 from pathlib import Path
-from openfisca_uk import Microsimulation, IndividualSim
+from openfisca_uk import (
+    Microsimulation,
+    IndividualSim,
+    CountryTaxBenefitSystem,
+)
 from openfisca_uk.entities import *
 from openfisca_uk_data import FRS_WAS_Imputation
 from policyengine.utils.general import PolicyEngineResultsConfig
@@ -25,6 +29,7 @@ class UKResultsConfig(PolicyEngineResultsConfig):
 
 class UK(PolicyEngineCountry):
     name = "uk"
+    system = CountryTaxBenefitSystem
     Microsimulation = Microsimulation
     IndividualSim = IndividualSim
     default_dataset = FRS_WAS_Imputation


### PR DESCRIPTION
# New feature: Current-policy calculation endpoint

This adds the default logic from the openfisca web api to policyengine, for the UK.

![image](https://user-images.githubusercontent.com/35577657/142699023-4204b3da-03cf-4aef-912e-3b173fa69687.png)

