### PR TITLE
Add named redirects

### DIFF
--- a/policyengine-client/src/App.jsx
+++ b/policyengine-client/src/App.jsx
@@ -3,6 +3,8 @@ import { BrowserRouter as Router, Route, Redirect } from "react-router-dom";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "./style/policyengine.less";
 import { PolicyEngineUK } from "./countries/uk";
+import { NamedPolicyRedirects } from "./common/layout";
+import { REDIRECTS } from "./data/namedPolicies";
 
 export default class App extends React.Component {
 	constructor(props) {
@@ -14,6 +16,7 @@ export default class App extends React.Component {
 		return (
 			<Router>
 				<Route path="/uk">
+					<NamedPolicyRedirects country="uk" namedPolicies={REDIRECTS.uk} page="/population-impact"/>
 					<PolicyEngineUK analytics={this.props.analytics} api_url="https://policyengine.org/uk/api" />
 				</Route>
 				<Route path="/us">

--- a/policyengine-client/src/common/layout.jsx
+++ b/policyengine-client/src/common/layout.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Container } from "react-bootstrap";
+import { Redirect } from "react-router";
 
 export function BodyWrapper(props) {
 	return (
@@ -20,4 +21,10 @@ export function PolicyEngineWrapper(props) {
             {props.children}
         </Container>
 	);
+}
+
+export function NamedPolicyRedirects(props) {
+	return Object.keys(props.namedPolicies).map(name => (
+		<Redirect from={`/${props.country}${name}`} to={`/${props.country}${props.page}?${props.namedPolicies[name]}`} />
+	));
 }

--- a/policyengine-client/src/data/namedPolicies.jsx
+++ b/policyengine-client/src/data/namedPolicies.jsx
@@ -1,0 +1,5 @@
+export const REDIRECTS = {
+    "uk": {
+        "/ubi-labs/resilience-ubi": "WA_adult_UBI_age=16&adult_UBI=184&child_UBI=92&senior_UBI=184&abolish_CB=1&abolish_CTC=1&abolish_ESA_income=1&abolish_IS=1&abolish_JSA_income=1&abolish_PC=1&abolish_SP=1&abolish_UC_carer=1&abolish_UC_child=1&abolish_UC_childcare=1&abolish_UC_standard=1&abolish_WTC=1&personal_allowance=0&higher_threshold=50000&add_rate=60&basic_rate=35&higher_rate=55&NI_add_rate=10&NI_class_4_add_rate=10&NI_class_4_main_rate=10&NI_main_rate=10"
+    }
+}

--- a/policyengine-client/src/data/namedPolicies.jsx
+++ b/policyengine-client/src/data/namedPolicies.jsx
@@ -1,5 +1,6 @@
 export const REDIRECTS = {
     "uk": {
-        "/ubi-labs/resilience-ubi": "WA_adult_UBI_age=16&adult_UBI=184&child_UBI=92&senior_UBI=184&abolish_CB=1&abolish_CTC=1&abolish_ESA_income=1&abolish_IS=1&abolish_JSA_income=1&abolish_PC=1&abolish_SP=1&abolish_UC_carer=1&abolish_UC_child=1&abolish_UC_childcare=1&abolish_UC_standard=1&abolish_WTC=1&personal_allowance=0&higher_threshold=50000&add_rate=60&basic_rate=35&higher_rate=55&NI_add_rate=10&NI_class_4_add_rate=10&NI_class_4_main_rate=10&NI_main_rate=10"
+        "/ubi-labs/resilience-ubi": "WA_adult_UBI_age=16&adult_UBI=184&child_UBI=92&senior_UBI=184&abolish_CB=1&abolish_CTC=1&abolish_ESA_income=1&abolish_IS=1&abolish_JSA_income=1&abolish_PC=1&abolish_SP=1&abolish_UC_carer=1&abolish_UC_child=1&abolish_UC_childcare=1&abolish_UC_standard=1&abolish_WTC=1&personal_allowance=0&higher_threshold=50000&add_rate=60&basic_rate=35&higher_rate=55&NI_add_rate=10&NI_class_4_add_rate=10&NI_class_4_main_rate=10&NI_main_rate=10",
+        "/ubi-labs/covid-dividend": "child_UBI=46&adult_UBI=92&senior_UBI=46&WA_adult_UBI_age=16"
     }
 }

--- a/policyengine/server.py
+++ b/policyengine/server.py
@@ -15,7 +15,7 @@ from policyengine.countries import UK, US, PolicyEngineCountry
 
 
 class PolicyEngine:
-    version: str = "1.1.4"
+    version: str = "1.1.5"
     cache_bucket_name: str = "uk-policy-engine.appspot.com"
     countries: Tuple[Type[PolicyEngineCountry]] = (UK, US)
 


### PR DESCRIPTION
# New feature: Named policy redirects

This adds a redirect for certain policies to their population impact page. For example, this PR adds:
* /uk/ubi-labs/covid-dividend -> /uk/population-impact/[Covid Dividend parameters]
* /uk/ubi-labs/resilience-ubi -> /uk/population-impact/[Resilience UBI parameters]

This is a first step, but might want to figure out the best way exactly to do this (currently, it's just a redirect, rather than an explicit naming of the reform (I looked into that, but seems it might be complex since a lot of the site relies on being able to check the URL contents). But one solution could be to do something like:

* /uk/population-impact/resilience-ubi = /uk/population-impact?parameter1=x...
* /uk/household/resilience-ubi = /uk/household?parameter1=x...

### Status
- [x] Cosmetic change
  - [x] Screenshots attached
- [ ] Back-end change
  - [ ] Unintuitive logic commented
- [ ] Version change
  - [ ] Major
  - [ ] Minor
  - [ ] Patch

