### PR TITLE
Add catch for bad parameters

### DIFF
--- a/policyengine-client/src/common/url.jsx
+++ b/policyengine-client/src/common/url.jsx
@@ -19,7 +19,11 @@ export function urlToPolicy(defaultPolicy) {
 	let plan = JSON.parse(JSON.stringify(defaultPolicy));
 	const { searchParams } = new URL(document.location);
 	for (const key of searchParams.keys()) {
-		plan[key].value = +searchParams.get(key) / (defaultPolicy[key].type === "rate" ? 100 : 1);
+		try {
+			plan[key].value = +searchParams.get(key) / (defaultPolicy[key].type === "rate" ? 100 : 1);
+		} catch {
+			// Bad parameter, do nothing
+		}
 	}
 	return plan;
 }


### PR DESCRIPTION
In order to not have the URLs with `abolish_CT=2` break, we need to add a catch when scraping the URL to get the policy.