### PR TITLE
Household

### DIFF
--- a/policyengine-client/src/common/pages/household.jsx
+++ b/policyengine-client/src/common/pages/household.jsx
@@ -129,6 +129,7 @@ export class HouseholdPage extends React.Component {
 	
 	componentDidMount() {
 		this.setState({autoComputeIntervalID: setInterval(this.autoComputeSituation, 2000)});
+		this.props.setHouseholdVisited();
 	}
 	 
 	componentWillUnmount() {
@@ -220,6 +221,7 @@ export default function Household(props) {
 			defaultSelectedName={props.defaultSelectedName}
 			defaultSelectedType={props.defaultSelectedType}
 			situationStructureButtons={props.situationStructureButtons}
+			setHouseholdVisited={props.setHouseholdVisited}
 		/>;
 	} else {
 		return <></>;

--- a/policyengine-client/src/common/url.jsx
+++ b/policyengine-client/src/common/url.jsx
@@ -3,9 +3,9 @@ export function policyToURL(targetPage, policy) {
 	for (const key in policy) {
 		if (policy[key].value !== policy[key].defaultValue) {
 			if(policy[key].unit === "/1") {
-				searchParams.set(key, Math.round(+policy[key].value * 100));
+				searchParams.set(key, (+policy[key].value * 100).toString().replace(".", "_"));
 			} else {
-				searchParams.set(key, +policy[key].value);
+				searchParams.set(key, (+policy[key].value).toString().replace(".", "_"));
 			}
 		} else {
 			searchParams.delete(key);
@@ -20,7 +20,7 @@ export function urlToPolicy(defaultPolicy) {
 	const { searchParams } = new URL(document.location);
 	for (const key of searchParams.keys()) {
 		try {
-			plan[key].value = +searchParams.get(key) / (defaultPolicy[key].unit === "/1" ? 100 : 1);
+			plan[key].value = +searchParams.get(key).replace("_", ".") / (defaultPolicy[key].unit === "/1" ? 100 : 1);
 		} catch {
 			// Bad parameter, do nothing
 		}

--- a/policyengine-client/src/countries/uk/app.jsx
+++ b/policyengine-client/src/countries/uk/app.jsx
@@ -100,7 +100,7 @@ export class PolicyEngineUK extends React.Component {
         const setPage = page => {this.setState({page: page});};
         return (
             <PolicyEngineWrapper>
-                <Route path="/uk">
+                <Route exact path="/uk">
                     <Redirect to="/uk/policy" />
                 </Route>
                 <Header country="uk" policy={this.state.policy} household={this.state.householdVisited}/>

--- a/policyengine-client/src/countries/uk/app.jsx
+++ b/policyengine-client/src/countries/uk/app.jsx
@@ -161,6 +161,7 @@ export class PolicyEngineUK extends React.Component {
                                 defaultSelectedName="You"
                                 defaultSelectedType="person"
                                 situationStructureButtons={situationButtons}
+                                setHouseholdVisited={() => this.setState({householdVisited: true})}
                             />
                         </Route>
                         <Route path="/uk/household-impact">

--- a/policyengine/__init__.py
+++ b/policyengine/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "1.3.0"
+VERSION = "1.3.1"

--- a/policyengine/countries/uk/__init__.py
+++ b/policyengine/countries/uk/__init__.py
@@ -22,8 +22,8 @@ class UKResultsConfig(PolicyEngineResultsConfig):
     working_age_variable: str = "is_WA_adult"
     senior_variable: str = "is_SP_age"
     person_variable: str = "people"
-    tax_variable: str = "tax"
-    benefit_variable: str = "benefits"
+    tax_variable: str = "household_tax"
+    benefit_variable: str = "household_benefits"
     earnings_variable: str = "employment_income"
 
 

--- a/policyengine/impact/population/metrics.py
+++ b/policyengine/impact/population/metrics.py
@@ -44,7 +44,8 @@ def headline_metrics(
     )
     gain = new_income - old_income
     net_cost = (
-        reformed.calc("net_income").sum() - baseline.calc("net_income").sum()
+        reformed.calc(config.household_net_income_variable).sum()
+        - baseline.calc(config.household_net_income_variable).sum()
     )
     poverty_change = pct_change(
         baseline.calc(config.in_poverty_variable, map_to="person").mean(),

--- a/policyengine/utils/charts.py
+++ b/policyengine/utils/charts.py
@@ -112,10 +112,14 @@ def waterfall_data(amounts: list, labels: list) -> pd.DataFrame:
 
 
 POP_LABELS = dict(
-    tax="Tax revenues", benefits="Benefit outlays", total="Net impact"
+    tax_variable="Tax revenues",
+    benefit_variable="Benefit outlays",
+    total="Net impact",
 )
 HH_LABELS = dict(
-    tax="Your taxes", benefits="Your benefits", total="Your net income"
+    tax_variable="Your taxes",
+    benefit_variable="Your benefits",
+    total="Your net income",
 )
 
 
@@ -142,7 +146,7 @@ def tax_benefit_waterfall_data(
         )
         for var, multiplier in zip(GROUPS, multipliers)
     ]
-    res = waterfall_data(effects, GROUPS)
+    res = waterfall_data(effects, ["tax_variable", "benefit_variable"])
     if is_pop:
         res.label = res.label.map(POP_LABELS)
     else:

--- a/policyengine/utils/general.py
+++ b/policyengine/utils/general.py
@@ -15,6 +15,8 @@ class PolicyEngineResultsConfig:
     senior_variable: str
     person_variable: str
     earnings_variable: str
+    tax_variable: str
+    benefit_variable: str
 
 
 def dict_to_string(d: dict) -> str:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/policyengine/policyengine",
     install_requires=[
-        "OpenFisca-UK==0.7.7",
+        "OpenFisca-UK==0.7.8",
         "OpenFisca-US==0.1.0",
         "OpenFisca-Tools>=0.1.7",
         "plotly",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/policyengine/policyengine",
     install_requires=[
-        "OpenFisca-UK==0.7.8",
+        "OpenFisca-UK==0.7.9",
         "OpenFisca-US==0.1.0",
         "OpenFisca-Tools>=0.1.7",
         "plotly",


### PR DESCRIPTION
This fixes a few bugs:
* Council Tax doesn't have a waterfall chart - the issue was that `tax`didn't include Council Tax. We're now using `household_tax` (and `household_benefits`).
* Policy links got directed straight to the policy page. The issue was a lack of an `exact` qualifier on the redirect function.
* URLs round their parameters - we now use underscores in place of decimal points.
