### PR TITLE
Multiply rates by 100

### DIFF
--- a/policyengine-client/src/common/parameter.jsx
+++ b/policyengine-client/src/common/parameter.jsx
@@ -73,7 +73,7 @@ export function Parameter(props) {
 		if(focused) {
 			formatter = x => x;
 		}
-		const onChange = value => {if(value != "") {props.updatePolicy(props.param.name, value)}};
+		const onChange = value => {if(value !== "") {props.updatePolicy(props.param.name, value)}};
 		let component;
 		if(props.param.valueType === "bool") {
 			if(props.param.unit === "abolition") {

--- a/policyengine-client/src/common/parameter.jsx
+++ b/policyengine-client/src/common/parameter.jsx
@@ -73,7 +73,7 @@ export function Parameter(props) {
 		if(focused) {
 			formatter = x => x;
 		}
-		const onChange = value => props.updatePolicy(props.param.name, value);
+		const onChange = value => {if(value != "") {props.updatePolicy(props.param.name, value)}};
 		let component;
 		if(props.param.valueType === "bool") {
 			if(props.param.unit === "abolition") {
@@ -113,6 +113,7 @@ export function Parameter(props) {
 			if(min) {
 				marks[min] = formatter(min);
 			}
+			const multiplier = props.param.unit === "/1" ? 100 : 1;
 			component = (
 				<>
 					<Slider
@@ -128,7 +129,7 @@ export function Parameter(props) {
 					/>
 					{
 						focused ?
-							<Input.Search enterButton="Enter" style={{maxWidth: 300}} placeholder={props.param.value} onSearch={value => {setFocused(false); onChange(value);}} /> :
+							<Input.Search enterButton="Enter" style={{maxWidth: 300}} placeholder={multiplier * props.param.value} onSearch={value => {setFocused(false); onChange(value / multiplier);}} /> :
 							<div>{(props.isComputed && props.loading) ? <Spin indicator={antIcon} /> : formatter(props.param.value)} <EditOutlined style={{marginLeft: 5}} onClick={() => setFocused(true)} /></div>
 					}
 				</>


### PR DESCRIPTION
# Improvement: Enter x% rather than x * 1 for rates

As above. Though yes @MaxGhenis I do agree on the extra click - in future, [this](https://ant.design/components/input-number/#components-input-number-demo-basic) might be a solution (`addonAfter`).

