### PR TITLE
Fix household calculations

### DIFF
--- a/policyengine-client/src/common/pages/household.jsx
+++ b/policyengine-client/src/common/pages/household.jsx
@@ -192,7 +192,7 @@ export class HouseholdPage extends React.Component {
 						page="household" 
 						policy={this.props.policy}
 						setPage={this.props.setPage} 
-						invalid={!this.props.policyValid} 
+						invalid={!this.props.policyValid || this.state.situationHasChanged} 
 						baseURL={this.props.baseURL}
 						situation={this.state.computedSituation}
 						variables={this.props.variables}

--- a/policyengine-client/src/countries/uk/data/situation.jsx
+++ b/policyengine-client/src/countries/uk/data/situation.jsx
@@ -54,7 +54,7 @@ export const HOUSEHOLD_VARIABLES = [
     "main_residence_value",
     "other_residential_property_value",
     "non_residential_property_value",
-    "expected_stamp_duty",
+    "expected_sdlt",
     "corporate_wealth",
     "land_value",
 ]


### PR DESCRIPTION
Caused by a variable rename `expected_stamp_duty` -> `expected_sdlt`. Filed https://github.com/PolicyEngine/policyengine/issues/280