### PR TITLE
Add household incidence

### DIFF
--- a/policyengine-client/src/countries/uk/data/policy.jsx
+++ b/policyengine-client/src/countries/uk/data/policy.jsx
@@ -138,7 +138,7 @@ export const PARAMETER_HIERARCHY = {
 		],
 		"Carbon Tax": [
 			"carbon_tax",
-			"carbon_tax_household_incidence",
+			"carbon_tax_consumer_incidence",
 		]
 	}
 };

--- a/policyengine-client/src/countries/uk/data/policy.jsx
+++ b/policyengine-client/src/countries/uk/data/policy.jsx
@@ -138,6 +138,7 @@ export const PARAMETER_HIERARCHY = {
 		],
 		"Carbon Tax": [
 			"carbon_tax",
+			"carbon_tax_household_incidence",
 		]
 	}
 };

--- a/policyengine/countries/uk/default_reform/reform.py
+++ b/policyengine/countries/uk/default_reform/reform.py
@@ -158,16 +158,16 @@ def create_default_reform() -> ReformType:
             total_emissions = (
                 emissions * household("household_weight", period)
             ).sum()
-            household_incidence = (
-                carbon_tax.household_incidence * rate * emissions
+            consumer_incidence = (
+                carbon_tax.consumer_incidence * rate * emissions
             )
             corporate_incidence = (
-                (1 - carbon_tax.household_incidence)
+                (1 - carbon_tax.consumer_incidence)
                 * rate
                 * total_emissions
                 * shareholding
             )
-            return household_incidence + corporate_incidence
+            return consumer_incidence + corporate_incidence
 
     class household_tax(baseline_variables["household_tax"]):
         def formula(household, period, parameters):

--- a/policyengine/countries/uk/default_reform/reform.py
+++ b/policyengine/countries/uk/default_reform/reform.py
@@ -151,8 +151,23 @@ def create_default_reform() -> ReformType:
         value_type = float
 
         def formula(household, period, parameters):
-            rate = parameters(period).reforms.carbon_tax.rate
-            return rate * household("carbon_consumption", period)
+            carbon_tax = parameters(period).reforms.carbon_tax
+            rate = carbon_tax.rate
+            emissions = household("carbon_consumption", period)
+            shareholding = household("shareholding", period)
+            total_emissions = (
+                emissions * household("household_weight", period)
+            ).sum()
+            household_incidence = (
+                carbon_tax.household_incidence * rate * emissions
+            )
+            corporate_incidence = (
+                (1 - carbon_tax.household_incidence)
+                * rate
+                * total_emissions
+                * shareholding
+            )
+            return household_incidence + corporate_incidence
 
     class household_tax(baseline_variables["household_tax"]):
         def formula(household, period, parameters):

--- a/policyengine/countries/uk/default_reform/reform.py
+++ b/policyengine/countries/uk/default_reform/reform.py
@@ -154,6 +154,7 @@ def create_default_reform() -> ReformType:
             carbon_tax = parameters(period).reforms.carbon_tax
             rate = carbon_tax.rate
             emissions = household("carbon_consumption", period)
+            # Household's share of total stocks and other corporate tax exposure.
             shareholding = household("shareholding", period)
             total_emissions = (
                 emissions * household("household_weight", period)

--- a/policyengine/countries/uk/reform_parameters.yaml
+++ b/policyengine/countries/uk/reform_parameters.yaml
@@ -53,13 +53,13 @@ reforms:
         unit: currency-GBP
         tests:
           - decreases_net_income: true
-    household_incidence:
+    consumer_incidence:
       description: Proportion of corporate carbon taxes which is passed on to consumers in the form of higher prices (as opposed to shareholders in the form of reduced profitability)
       values:
         2021-01-01: 1.00
       metadata:
-        label: Carbon tax household incidence
-        name: carbon_tax_household_incidence
+        label: Carbon tax consumer incidence
+        name: carbon_tax_consumer_incidence
         max: 1
         unit: /1
   wealth_tax:

--- a/policyengine/countries/uk/reform_parameters.yaml
+++ b/policyengine/countries/uk/reform_parameters.yaml
@@ -53,6 +53,15 @@ reforms:
         unit: currency-GBP
         tests:
           - decreases_net_income: true
+    household_incidence:
+      description: Proportion of corporate carbon taxes which is passed on to consumers in the form of higher prices (as opposed to shareholders in the form of reduced profitability)
+      values:
+        2021-01-01: 1.00
+      metadata:
+        label: Carbon tax household incidence
+        name: carbon_tax_household_incidence
+        max: 1
+        unit: /1
   wealth_tax:
     rate:
       description: A yearly flat tax on net financial wealth


### PR DESCRIPTION
Adds a parameter to adjust the consumer (vs shareholder) incidence of carbon taxes. Defaults to 100%.