### PR TITLE
Improve stability on household impact

### DIFF
--- a/policyengine-client/src/common/pages/household.jsx
+++ b/policyengine-client/src/common/pages/household.jsx
@@ -121,7 +121,7 @@ function HouseholdVariables(props) {
 export class HouseholdPage extends React.Component {
 	constructor(props) {
 		super(props);
-		this.state = {selected: {name: props.defaultSelectedName, type: props.defaultSelectedType}, error: false, situation: props.situation, computedSituation: props.situation, situationValid: true, autoComputeIntervalID: null, situationHasChanged: true};
+		this.state = {waiting: false, selected: {name: props.defaultSelectedName, type: props.defaultSelectedType}, error: false, situation: props.situation, computedSituation: props.situation, situationValid: true, autoComputeIntervalID: null, situationHasChanged: true};
 		this.updateSituation = this.updateSituation.bind(this);
 		this.autoComputeSituation = this.autoComputeSituation.bind(this);
 	}
@@ -142,8 +142,8 @@ export class HouseholdPage extends React.Component {
 	}
 
 	autoComputeSituation() {
-		if(this.state.situationHasChanged) {
-			fetch(this.props.api_url + "/calculate", {
+		if(this.state.situationHasChanged && !this.state.waiting) {
+			this.setState({waiting: true}, () => {fetch(this.props.api_url + "/calculate", {
 				method: "POST",
 				headers: {
 					'Accept': 'application/json',
@@ -151,9 +151,9 @@ export class HouseholdPage extends React.Component {
 				},
 				body: JSON.stringify(this.state.situation),
 			}).then(response => response.json()).then(situation => {
-				this.setState({computedSituation: situation, situationValid: true, situationHasChanged: false});
+				this.setState({waiting: false, computedSituation: situation, situationValid: true, situationHasChanged: false});
 				this.props.updateSituation(this.state.situation, this.state.computedSituation);
-			}).catch((e) => this.setState({situationHasChanged: false, error: true}));
+			}).catch((e) => this.setState({situationHasChanged: false, error: true}))});
 		}
 	}
 

--- a/policyengine/utils/reforms.py
+++ b/policyengine/utils/reforms.py
@@ -262,7 +262,7 @@ def create_reform(
             metadata = policyengine_parameters[param]
             name = metadata["label"]
             description = get_summary(metadata, value)
-            if "abolish" in param:
+            if metadata["unit"] == "abolition":
                 if metadata["variable"] is not None:
                     if isinstance(metadata["variable"], list):
                         reform = tuple(


### PR DESCRIPTION
This should hopefully fix some phantom bugs I haven't been able to consistently reproduce - occasionally, the household impact fails to load. I've set the "view household impact" button to wait until household computations are done and made the reform parsing more robust.