### PR TITLE
Add synthetic mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ publish-client:
 	cd policyengine-client; npm publish
 debug-server:
 	FLASK_APP=policyengine/server.py FLASK_DEBUG=1 flask run
+debug-server-synth: 
+	POLICYENGINE_SYNTH_UK=1 make debug-server
 debug-client:
 	cd policyengine-client; npm start
 format:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,4 @@ First, install using `make install`. Then, to debug the client, run `make debug-
 
 If your changes involve the server, change `const useLocalServer = false;` to `const useLocalServer = true;` in `src/App.jsx`.
 
-If you don't have access to the UK Family Resources Survey, you can still run the UK population-wide calculator on an anonymised version. To do that, in `policyengine/countries/uk/__init__.py` change:
-
-`use_synthetic_data = False` to `use_synthetic_data = True`
+If you don't have access to the UK Family Resources Survey, you can still run the UK population-wide calculator on an anonymised version. To do that, instead of running `make debug-server`, run `POLICYENGINE_SYNTH_UK=1 make debug-server`

--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ This repository contains the core infrastructure for PolicyEngine sites in order
 First, install using `make install`. Then, to debug the client, run `make debug-client`, or to debug the server, run `make debug-server`.
 
 If your changes involve the server, change `const useLocalServer = false;` to `const useLocalServer = true;` in `src/App.jsx`.
+
+If you don't have access to the UK Family Resources Survey, you can still run the UK population-wide calculator on an anonymised version. To do that, in `policyengine/countries/uk/__init__.py` change:
+
+`use_synthetic_data = False` to `use_synthetic_data = True`

--- a/policyengine/countries/uk/__init__.py
+++ b/policyengine/countries/uk/__init__.py
@@ -9,6 +9,7 @@ from openfisca_uk_data import FRSEnhanced, SynthFRS
 from policyengine.utils.general import PolicyEngineResultsConfig
 from policyengine.countries.country import PolicyEngineCountry
 from policyengine.countries.uk.default_reform import create_default_reform
+import os
 
 UK_FOLDER = Path(__file__).parent
 
@@ -28,7 +29,6 @@ class UKResultsConfig(PolicyEngineResultsConfig):
 
 
 class UK(PolicyEngineCountry):
-    use_synthetic_data = True
     name = "uk"
     system = CountryTaxBenefitSystem
     Microsimulation = Microsimulation
@@ -43,7 +43,10 @@ class UK(PolicyEngineCountry):
     results_config = UKResultsConfig
 
     def __init__(self):
-        if self.use_synthetic_data:
+        if (
+            "POLICYENGINE_SYNTH_UK" in os.environ
+            and os.environ["POLICYENGINE_SYNTH_UK"]
+        ):
             self.default_dataset = SynthFRS
             if len(SynthFRS.years) == 0:
                 # No synthetic data - download from GitHub

--- a/policyengine/countries/uk/__init__.py
+++ b/policyengine/countries/uk/__init__.py
@@ -5,7 +5,7 @@ from openfisca_uk import (
     CountryTaxBenefitSystem,
 )
 from openfisca_uk.entities import *
-from openfisca_uk_data import FRSEnhanced
+from openfisca_uk_data import FRSEnhanced, SynthFRS
 from policyengine.utils.general import PolicyEngineResultsConfig
 from policyengine.countries.country import PolicyEngineCountry
 from policyengine.countries.uk.default_reform import create_default_reform
@@ -28,6 +28,7 @@ class UKResultsConfig(PolicyEngineResultsConfig):
 
 
 class UK(PolicyEngineCountry):
+    use_synthetic_data = True
     name = "uk"
     system = CountryTaxBenefitSystem
     Microsimulation = Microsimulation
@@ -40,3 +41,11 @@ class UK(PolicyEngineCountry):
     entity_hierarchy_file = UK_FOLDER / "entities.yaml"
     version = "0.2.0"
     results_config = UKResultsConfig
+
+    def __init__(self):
+        if self.use_synthetic_data:
+            self.default_dataset = SynthFRS
+            if len(SynthFRS.years) == 0:
+                # No synthetic data - download from GitHub
+                SynthFRS.save(2019)
+        super().__init__()

--- a/policyengine/countries/uk/__init__.py
+++ b/policyengine/countries/uk/__init__.py
@@ -47,5 +47,5 @@ class UK(PolicyEngineCountry):
             self.default_dataset = SynthFRS
             if len(SynthFRS.years) == 0:
                 # No synthetic data - download from GitHub
-                SynthFRS.save(2019)
+                SynthFRS.save(year=2019)
         super().__init__()


### PR DESCRIPTION
# New feature: Synthetic mode for the UK system

This adds a way for everyone who doesn't have access to the UK microdata to run the server - it should work as described in the README (just changing a bool option from false to true).

