### PR TITLE
Add option for local client-only debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This repo consists of two packages - the React client and the Python server. A change to either repo should trigger an update in the versions for both to ensure a consistent changelog in this repo.
 
+## [1.4.2] - 2022-01-12
+
+### Added
+
+* An option to use the policyengine.org server when debugging, rather than inferring from the URL.
+
 ## [1.4.1] - 2022-01-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ This repository contains the core infrastructure for PolicyEngine sites in order
 First, install using `make install`. Then, to debug the client, run `make debug-client`, or to debug the server, run `make debug-server`.
 
 If your changes involve the server, change `useLocalServer = false;` to `useLocalServer = true;` in `policyengine-client/src/countries/country.jsx`.
+Otherwise, change `usePolicyEngineOrgServer = false;` to `usePolicyEngineOrgServer = true;` in `policyengine-client/src/countries/country.jsx`.
 
 If you don't have access to the UK Family Resources Survey, you can still run the UK population-wide calculator on an anonymised version. To do that, instead of running `make debug-server`, run `POLICYENGINE_SYNTH_UK=1 make debug-server`

--- a/policyengine-client/package.json
+++ b/policyengine-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "policyengine-client",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "dependencies": {
     "@ant-design/icons": "^4.7.0",
     "@emotion/react": "^11.5.0",

--- a/policyengine-client/src/countries/country.jsx
+++ b/policyengine-client/src/countries/country.jsx
@@ -96,6 +96,7 @@ export default class Country {
     }
 
     useLocalServer = false;
+    usePolicyEngineOrgServer = false;
 }
 
 export const CountryContext = createContext(null);

--- a/policyengine-client/src/countries/uk/uk.jsx
+++ b/policyengine-client/src/countries/uk/uk.jsx
@@ -37,8 +37,12 @@ export class UK extends Country {
     constructor() {
         super();
         this.baseApiUrl = !this.useLocalServer ?
-                        `${window.location.protocol}//${window.location.hostname}` :
-                        `http://localhost:5000`;
+                            (
+                                this.usePolicyEngineOrgServer ?
+                                    "https://policyengine.org/" :
+                                    `${window.location.protocol}//${window.location.hostname}`
+                            ) :
+                            `http://localhost:5000`;
         this.apiURL = `${this.baseApiUrl}/${this.name}/api`;
     }
     name = "uk"

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -16,8 +16,12 @@ export class US extends Country {
     constructor() {
         super();
         this.baseApiUrl = !this.useLocalServer ?
-                        `${window.location.protocol}//${window.location.hostname}` :
-                        `http://localhost:5000`;
+                            (
+                                this.usePolicyEngineOrgServer ?
+                                    "https://policyengine.org/" :
+                                    `${window.location.protocol}//${window.location.hostname}`
+                            ) :
+                            `http://localhost:5000`;
         this.apiURL = `${this.baseApiUrl}/${this.name}/api`;
     }
     name = "us"

--- a/policyengine/__init__.py
+++ b/policyengine/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "1.4.1"
+VERSION = "1.4.2"


### PR DESCRIPTION
This PR adds an option in `country.jsx` for changes only involving the client - previously, the API URL was derived from the current URL (this is required for the beta site). I've added to the README specifying this.