### PR TITLE
Add SNAP inputs and update openfisca-US

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This repo consists of two packages - the React client and the Python server. A change to either repo should trigger an update in the versions for both to ensure a consistent changelog in this repo.
 
+## [1.6.0] - 2022-01-17
+
+### Added
+
+* More inputs for calculating US SNAP benefits.
+
 ## [1.5.5] - 2022-01-16
 
 ### Changed

--- a/policyengine-client/src/countries/country.jsx
+++ b/policyengine-client/src/countries/country.jsx
@@ -96,7 +96,7 @@ export default class Country {
         });
     }
 
-    useLocalServer = true;
+    useLocalServer = false;
     usePolicyEngineOrgServer = false;
 }
 

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -109,6 +109,7 @@ export class US extends Country {
         "is_surviving_spouse_of_disabled_veteran",
         "is_surviving_child_of_disabled_veteran",
         // SPM unit.
+        "ssi",
         "housing_cost",
         "childcare_expenses",
         // Household.
@@ -136,6 +137,7 @@ export class US extends Country {
             "is_surviving_child_of_disabled_veteran",
         ],
         "SPM unit": [
+            "ssi",
             "housing_cost",
             "childcare_expenses",
         ],

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -96,8 +96,8 @@ export class US extends Country {
         }
     }
     inputVariables = [
+        // Person.
         "age",
-        "state_code",
         "employment_income",
         "self_employment_income",
         "dividend_income",
@@ -108,6 +108,11 @@ export class US extends Country {
         "is_permanently_disabled_veteran",
         "is_surviving_spouse_of_disabled_veteran",
         "is_surviving_child_of_disabled_veteran",
+        // SPM unit.
+        "housing_cost",
+        "childcare_expenses",
+        // Household.
+        "state_code",
     ]
     outputVariables = [
         "spm_unit_net_income",
@@ -129,6 +134,10 @@ export class US extends Country {
             "is_permanently_disabled_veteran",
             "is_surviving_spouse_of_disabled_veteran",
             "is_surviving_child_of_disabled_veteran",
+        ],
+        "SPM unit": [
+            "housing_cost",
+            "childcare_expenses",
         ],
         "Household": [
             "state_code",

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -42,10 +42,7 @@ export class US extends Country {
     showHousehold = true
     showFAQ = true
     // Vanity URLs
-    namedPolicies = {
-        "/ubi-labs/resilience-ubi": "WA_adult_UBI_age=16&adult_UBI=184&child_UBI=92&senior_UBI=184&abolish_CB=1&abolish_CTC=1&abolish_ESA_income=1&abolish_IS=1&abolish_JSA_income=1&abolish_PC=1&abolish_SP=1&abolish_UC_carer=1&abolish_UC_child=1&abolish_UC_childcare=1&abolish_UC_standard=1&abolish_WTC=1&personal_allowance=0&higher_threshold=50000&add_rate=60&basic_rate=35&higher_rate=55&NI_add_rate=10&NI_class_4_add_rate=10&NI_class_4_main_rate=10&NI_main_rate=10",
-        "/ubi-labs/covid-dividend": "child_UBI=46&adult_UBI=92&senior_UBI=46&WA_adult_UBI_age=16"
-    }
+    namedPolicies = {}
     validatePolicy = validatePolicy;
     // Policy page metadata
     parameterHierarchy = {

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -98,7 +98,10 @@ export class US extends Country {
     inputVariables = [
         "age",
         "state_code",
-        "market_income",
+        "employment_income",
+        "self_employment_income",
+        "dividend_income",
+        "interest_income",
     ]
     outputVariables = [
         "spm_unit_net_income",
@@ -111,7 +114,7 @@ export class US extends Country {
         "Personal": [
             "age",
             "employment_income",
-            "self_employed_income",
+            "self_employment_income",
             "dividend_income",
             "interest_income",
         ],

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -111,6 +111,7 @@ export class US extends Country {
         "childcare_expenses",
         // Household.
         "state_code",
+        "is_homeless",
     ]
     outputVariables = [
         "spm_unit_net_income",
@@ -140,6 +141,7 @@ export class US extends Country {
         ],
         "Household": [
             "state_code",
+            "is_homeless",
         ]
     }
     defaultOpenVariableGroups = []

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -110,7 +110,10 @@ export class US extends Country {
         "General": [],
         "Personal": [
             "age",
-            "market_income",
+            "employment_income",
+            "self_employed_income",
+            "dividend_income",
+            "interest_income",
         ],
         "Household": [
             "state_code",

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -54,6 +54,9 @@ export class US extends Country {
             ],
             "Deductions": [
                 "snap_earned_income_deduction",
+                "snap_medical_expense_disregard",
+                "snap_homeless_shelter_deduction",
+                "snap_shelter_deduction_income_share_disregard",
             ]
         }
     }

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -102,6 +102,7 @@ export class US extends Country {
         "self_employment_income",
         "dividend_income",
         "interest_income",
+        "medical_out_of_pocket_expenses",
     ]
     outputVariables = [
         "spm_unit_net_income",
@@ -117,6 +118,7 @@ export class US extends Country {
             "self_employment_income",
             "dividend_income",
             "interest_income",
+            "medical_out_of_pocket_expenses",
         ],
         "Household": [
             "state_code",

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -103,6 +103,11 @@ export class US extends Country {
         "dividend_income",
         "interest_income",
         "medical_out_of_pocket_expenses",
+        "ssdi",
+        "is_ssi_disabled",
+        "is_permanently_disabled_veteran",
+        "is_surviving_spouse_of_disabled_veteran",
+        "is_surviving_child_of_disabled_veteran",
     ]
     outputVariables = [
         "spm_unit_net_income",
@@ -119,6 +124,11 @@ export class US extends Country {
             "dividend_income",
             "interest_income",
             "medical_out_of_pocket_expenses",
+            "ssdi",
+            "is_ssi_disabled",
+            "is_permanently_disabled_veteran",
+            "is_surviving_spouse_of_disabled_veteran",
+            "is_surviving_child_of_disabled_veteran",
         ],
         "Household": [
             "state_code",

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -56,7 +56,7 @@ export class US extends Country {
                 "snap_net_income_limit_standard",
             ],
             "Deductions": [
-                "snap_earnings_deduction",
+                "snap_earned_income_deduction",
             ]
         }
     }
@@ -102,7 +102,7 @@ export class US extends Country {
     ]
     outputVariables = [
         "spm_unit_net_income",
-        "snap_max_benefit",
+        "snap_max_allotment",
         "snap_expected_contribution",
         "snap",
     ]

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -13,24 +13,24 @@ const childNamer = {
 }
 
 function validatePolicy(policy, defaultPolicy) {
-    if(defaultPolicy) {
-        for(let parameter in policy) {
+    if (defaultPolicy) {
+        for (let parameter in policy) {
             policy[parameter].defaultValue = defaultPolicy[parameter].value;
         }
     }
-    return {policy: policy, policyValid: true};
+    return { policy: policy, policyValid: true };
 }
 
 export class US extends Country {
     constructor() {
         super();
         this.baseApiUrl = !this.useLocalServer ?
-                            (
-                                this.usePolicyEngineOrgServer ?
-                                    "https://policyengine.org/" :
-                                    `${window.location.protocol}//${window.location.hostname}`
-                            ) :
-                            `http://localhost:5000`;
+            (
+                this.usePolicyEngineOrgServer ?
+                    "https://policyengine.org/" :
+                    `${window.location.protocol}//${window.location.hostname}`
+            ) :
+            `http://localhost:5000`;
         this.apiURL = `${this.baseApiUrl}/${this.name}/api`;
     }
     name = "us"
@@ -108,7 +108,7 @@ export class US extends Country {
     ]
     inputVariableHierarchy = {
         "General": [],
-        "Personal" : [
+        "Personal": [
             "age",
             "market_income",
         ],
@@ -127,7 +127,7 @@ export class US extends Country {
         },
         "snap": {
             "add": [
-                "snap_max_benefit",
+                "snap_max_allotment",
             ],
             "subtract": [
                 "snap_expected_contribution",
@@ -139,7 +139,7 @@ export class US extends Country {
     addPartner(situation) {
         const name = "Your partner"
         situation.people[name] = {
-            "age": {"2021": 25},
+            "age": { "2021": 25 },
         };
         situation.families["Your family"].members.push(name);
         situation.tax_units["Your tax unit"].members.push(name);
@@ -147,11 +147,11 @@ export class US extends Country {
         situation.households["Your household"].members.push(name);
         return this.validateSituation(situation).situation;
     }
-    
+
     addChild(situation) {
         const childName = childNamer[this.getNumChildren() + 1];
         situation.people[childName] = {
-            "age": {"2021": 10},
+            "age": { "2021": 10 },
         };
         situation.families["Your family"].members.push(childName);
         situation.tax_units["Your tax unit"].members.push(childName);
@@ -159,11 +159,11 @@ export class US extends Country {
         situation.households["Your household"].members.push(childName);
         return this.validateSituation(situation).situation;
     }
-    
+
     removePerson(situation, name) {
-        for(let entityPlural of ["tax_units", "families", "spm_units", "households"]) {
-            for(let entity of Object.keys(situation[entityPlural])) {
-                if(situation[entityPlural][entity].members.includes(name)) {
+        for (let entityPlural of ["tax_units", "families", "spm_units", "households"]) {
+            for (let entity of Object.keys(situation[entityPlural])) {
+                if (situation[entityPlural][entity].members.includes(name)) {
                     situation[entityPlural][entity].members.pop(name);
                 }
             }
@@ -171,46 +171,48 @@ export class US extends Country {
         delete situation.people[name];
         return this.validateSituation(situation).situation;
     }
-    
+
     setNumAdults(numAdults) {
         let situation = this.situation;
         const numExistingAdults = this.getNumAdults();
-        if(numExistingAdults === 1 && numAdults === 2) {
+        if (numExistingAdults === 1 && numAdults === 2) {
             situation = this.addPartner(situation);
-        } else if(numExistingAdults === 2 && numAdults === 1) {
+        } else if (numExistingAdults === 2 && numAdults === 1) {
             situation = this.removePerson(situation, "Your partner");
         }
 
         this.setState({
-            situation: this.validateSituation(situation).situation, 
+            situation: this.validateSituation(situation).situation,
             baselineSituationImpactIsOutdated: true,
             reformSituationImpactIsOutdated: true,
-        });    }
+        });
+    }
 
     getNumAdults() {
         return this.situation.households["Your household"].members.filter(
             name => this.situation.people[name].age["2021"] >= 18
         ).length;
     }
-    
+
     setNumChildren(numChildren) {
         let situation = this.situation;
         const numExistingChildren = this.getNumChildren();
-        if(numExistingChildren < numChildren) {
-            for(let i = numExistingChildren; i < numChildren; i++) {
+        if (numExistingChildren < numChildren) {
+            for (let i = numExistingChildren; i < numChildren; i++) {
                 situation = this.addChild(situation);
             }
-        } else if(numExistingChildren > numChildren) {
-            for(let i = numExistingChildren; i > numChildren; i--) {
+        } else if (numExistingChildren > numChildren) {
+            for (let i = numExistingChildren; i > numChildren; i--) {
                 situation = this.removePerson(situation, childNamer[i]);
             }
         }
 
         this.setState({
-            situation: this.validateSituation(situation).situation, 
+            situation: this.validateSituation(situation).situation,
             baselineSituationImpactIsOutdated: true,
             reformSituationImpactIsOutdated: true,
-        });    }
+        });
+    }
 
     getNumChildren() {
         return this.situation.households["Your household"].members.filter(

--- a/policyengine/__init__.py
+++ b/policyengine/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "1.5.5"
+VERSION = "1.6.0"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url="https://github.com/policyengine/policyengine",
     install_requires=[
         "OpenFisca-UK==0.10.6",
-        "OpenFisca-US==0.24.0",
+        "OpenFisca-US==0.24.1",
         "OpenFisca-Tools>=0.2.2",
         "plotly",
         "flask",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url="https://github.com/policyengine/policyengine",
     install_requires=[
         "OpenFisca-UK==0.10.5",
-        "OpenFisca-US==0.23.1",
+        "OpenFisca-US==0.24.0",
         "OpenFisca-Tools>=0.1.7",
         "plotly",
         "flask",


### PR DESCRIPTION
Adds more inputs to the US screen to improve SNAP calculation and update to the latest version of OpenFisca-US, which improves SNAP calculations. Specifically it includes:
* Earned income sources: employment & self-employment income
* Unearned income sources: dividend & interest income
* Medical expense deduction inputs: medical out of pocket expenses
* Inputs for special disability rules: SSDI, SSI disabled, and disabled veteran status or family member
* Categorical eligibility inputs: SSI
* Shelter deduction inputs: housing costs and homelessness
* Dependent care deduction inputs: childcare expenses (NB: this doesn't look good because we need units, see PolicyEngine/openfisca-us#496)

I omitted `spm_unit_assets` because we don't have stocks/flows yet in openfisca-us (to my knowledge?) and because California doesn't have an asset limit (due to BBCE).

Adding more parameters will require naming them in openfisca-us, plus in many cases a state drop-down.

I also removed UK-specific vanity URLs from the US page.

Here's how it looks. I had to create a SPM unit section, but we can fix that as @nikhilwoodruff is doing on the UK side to combine household-like entities.
![image](https://user-images.githubusercontent.com/6076111/149838093-a4d7a95a-0be5-4b7b-abb3-22aa0186f302.png)
