### PR TITLE
Household-reorganise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This repo consists of two packages - the React client and the Python server. A c
 
 ### Fixed
 
+* A bug which caused the UK household impact to be blank and the US to not show the household structure panel.
+
+## [1.7.1] - 2022-01-18
+
+### Fixed
+
 * Gini index is calculated from disposable (not equivalised) household income.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This repo consists of two packages - the React client and the Python server. A change to either repo should trigger an update in the versions for both to ensure a consistent changelog in this repo.
 
-## [1.7.1] - 2022-01-18
+## [1.7.2] - 2022-01-18
 
 ### Fixed
 

--- a/policyengine-client/package.json
+++ b/policyengine-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "policyengine-client",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "dependencies": {
     "@ant-design/icons": "^4.7.0",
     "@emotion/react": "^11.5.0",

--- a/policyengine-client/src/countries/country.jsx
+++ b/policyengine-client/src/countries/country.jsx
@@ -96,7 +96,7 @@ export default class Country {
         });
     }
 
-    useLocalServer = true;
+    useLocalServer = false;
     usePolicyEngineOrgServer = false;
 }
 

--- a/policyengine-client/src/countries/country.jsx
+++ b/policyengine-client/src/countries/country.jsx
@@ -96,7 +96,7 @@ export default class Country {
         });
     }
 
-    useLocalServer = false;
+    useLocalServer = true;
     usePolicyEngineOrgServer = false;
 }
 

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -123,7 +123,9 @@ export class US extends Country {
         "snap",
     ]
     inputVariableHierarchy = {
-        "General": [],
+        "General": [
+            "setup",
+        ],
         "Personal": [
             "age",
             "employment_income",

--- a/policyengine-client/src/policyengine/pages/household/inputPane.jsx
+++ b/policyengine-client/src/policyengine/pages/household/inputPane.jsx
@@ -33,7 +33,7 @@ export class VariableControlPane extends React.Component {
     }
 
     render() {
-        if(this.props.selected === "/Household/Structure") {
+        if((this.props.variables.length > 0) && this.props.variables.includes("setup")) {
 			// Show variables controlling the structure of the household
 			return <HouseholdSetup />
 		}

--- a/policyengine/__init__.py
+++ b/policyengine/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "1.7.1"
+VERSION = "1.7.2"


### PR DESCRIPTION
@MaxGhenis it turned out to be because the flag for "show household people selector" was misnamed on the UK (page failed completely) and missing on the US (just the household people selector didn't display).