### PR TITLE
Resurrect policyengine.org

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -559,3 +559,7 @@
     changed:
     - Update budget hovercard for when there is no reform.
   date: 2022-04-16 17:10:04
+- bump: patch
+  changes:
+    fixed:
+    - Blog API failure doesn't crash the site.

--- a/policyengine-client/src/landing.jsx
+++ b/policyengine-client/src/landing.jsx
@@ -90,8 +90,12 @@ class MediumFeed extends React.Component {
     }
 
     componentDidMount() {
-        fetch("https://api.rss2json.com/v1/api.json?rss_url=https%3A%2F%2Fmedium.com%2Ffeed%2Fpolicyengine").then(res => res.json()).then(feed => {
-            this.setState({ feed: feed });
+        fetch("https://api.rss2json.com/v1/api.json?rss_url=https%3A%2F%2Fmedium.com%2Ffeed%2Fpolicyengine").then(res => res.json()).then(res => {
+            if(res.status === "error") {
+                this.setState({ feed: { items: [] } });
+            } else {
+                this.setState({ feed: res });
+            }
         });
     }
 


### PR DESCRIPTION
I think the issue is our API to access the Medium blog feed changed or broke. In the meantime, this replaces the posts with an empty list to ensure the site itself stays up. 

Site crash reproduced locally and fixed locally within this PR.