### PR TITLE
Revert memory increase

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -2,7 +2,7 @@ runtime: custom
 env: flex
 resources:
   cpu: 1
-  memory_gb: 8
+  memory_gb: 6
   disk_size_gb: 32
 automatic_scaling:
   min_num_instances: 1

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -595,3 +595,7 @@
     fixed:
     - Download instead of generate the CPS dataset for the US microsimulation.
   date: 2022-04-22 13:47:44
+- bump: patch
+  changes:
+    fixed:
+    - Memory allocation reduced back to 6GB (unnecessary given previous PR).


### PR DESCRIPTION
It turns out we can have a maximum of 6.5GB per CPU on gcloud, so we'd need to add an extra CPU. But I'm not sure we need to, as I think the memory requirement mentioned in #671 was a misdiagnosis and https://github.com/PolicyEngine/openfisca-us/pull/709 fixed the actual issue.