### PR TITLE
Fix descriptions bugs

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -642,3 +642,7 @@
     added:
     - API explorer improvements.
   date: 2022-04-29 12:46:58
+- bump: patch
+  changes:
+    fixed:
+    - Fixed a bug causing incorrect descriptions for variables without descriptions.

--- a/policyengine/utils/situations.py
+++ b/policyengine/utils/situations.py
@@ -36,6 +36,8 @@ def get_PE_variables(system: TaxBenefitSystem) -> Dict[str, dict]:
                 description = variable.documentation
                 if description[-1] != ".":
                     description += "."
+            else:
+                description = None
             variable_metadata[variable.name] = dict(
                 name=variable.name,
                 unit=variable.unit,


### PR DESCRIPTION
This was introduced by me about two hours ago, when adding the descriptions to the API explorer. It affects variables without a description provided (they get incorrectly assigned the last successfully loaded descriptions). 