### PR TITLE
Display image with actual aspect ratio

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -670,3 +670,8 @@
     fixed:
     - Fixed a bug which prevented the country specifier from applying.
   date: 2022-05-04 18:41:39
+- bump: minor
+  changes:
+    changed:
+    - Size logo image to actual aspect ratio.
+

--- a/policyengine-client/src/policyengine/header/title.jsx
+++ b/policyengine-client/src/policyengine/header/title.jsx
@@ -16,7 +16,6 @@ export default function Title(props) {
 				src={MainLogo}
 				preview={false}
 				height={50}
-				width={80}
 				style={{ padding: 0, margin: 0 }}
 			/>
 		</a>


### PR DESCRIPTION
Issue #666 

Per Lighthouse, display logo image with actual aspect ratio.

Before
<img width="1425" alt="Screen Shot 2022-05-07 at 17 03 51" src="https://user-images.githubusercontent.com/60083841/167279894-c70b46f3-8fc5-411c-81c0-22da07ed45fd.png">


After
<img width="1425" alt="Screen Shot 2022-05-07 at 17 05 08" src="https://user-images.githubusercontent.com/60083841/167279895-c32594d5-bd6c-4bb1-8385-1a750ec9a206.png">

