### PR TITLE
Breakdown parameter improvements

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -775,3 +775,8 @@
     added:
     - Massachusetts State income tax policy parameters.
   date: 2022-06-08 06:51:11
+- bump: minor
+  changes:
+    changed:
+    - OpenFisca-US bumped to 0.72.2.
+    - Breakdown parameters are now borderless.

--- a/policyengine-client/src/policyengine/pages/policy/parameter.jsx
+++ b/policyengine-client/src/policyengine/pages/policy/parameter.jsx
@@ -132,7 +132,7 @@ function BreakdownParameterControl(props) {
 		});
 		let possibleKeys = [...new Set(possibleValues.map(value => value[0]))];
 		dropDowns.push(
-			<Select key={i} defaultValue={possibleKeys[0]} style={{marginRight: 10}} onChange={target => {
+			<Select key={i} defaultValue={possibleKeys[0]} style={{marginLeft: 0, paddingLeft: 0}} bordered={false} onChange={target => {
 				let selectedCopy = [...selected];
 				selectedCopy[i] = target;
 				setSelected(selectedCopy);

--- a/policyengine-client/src/style/policyengine.less
+++ b/policyengine-client/src/style/policyengine.less
@@ -101,3 +101,7 @@ h4 {
     color: #0b5394;
     line-height: 1.8;
 }
+
+div.ant-select-selector {
+    padding-left: 0px !important;
+}


### PR DESCRIPTION
Makes breakdown parameters borderless, and fix the capitalised breakdown names in the MA section.