### PR TITLE
Bug fix: Married status in US

### DIFF
--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -690,9 +690,9 @@ export class US extends Country {
 
     setHouseholdMaritalStatus(status) {
         let situation = this.situation;
-        if (status === "Married" & !situation.people.includes("Your spouse")) {
+        if (status === "Married" & !situation.people.hasOwnProperty("Your spouse")) {
             this.addPartner(situation);
-        } else if (status === "Single" & situation.people.includes("Your spouse")) {
+        } else if (status === "Single" & situation.people.hasOwnProperty("Your spouse")) {
             this.removePerson(situation, "Your spouse");
         }
         this.setState({


### PR DESCRIPTION

### Steps to test

1. Visit [PolicyEngine US Household page](https://policyengine.org/us/household)
2. Switch from Single to Married
3. Go to one of the People menus, e.g. Income
4. Return to the Household > People menu


### Issues fixed

fixes #813 

