### PR TITLE
Don't publish to NPM if version is lower than latest

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -146,4 +146,4 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: policyengine-client/package.json
-          greaterVersionOnly: true
+          greater-version-only: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,6 @@ jobs:
           options: ". -l 79 --check"
   test:
     name: Test and Deploy
-    needs: publish
     runs-on: ubuntu-latest
     if: |
       (github.repository == 'PolicyEngine/policyengine')
@@ -147,3 +146,4 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: policyengine-client/package.json
+          greaterVersionOnly: true


### PR DESCRIPTION
cc @MaxGhenis - this should fix redeployments for all commits after this is merged.