### PR TITLE
Center logo mobile

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: minor
   changes:
     added:
-      - Policy logo and Beta block are now centered.
+      - Policy logo and Beta block are now centered. 

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Light Gray shading and button spacing for Desktop view in policy overview.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: minor
   changes:
     added:
-      - Light Gray shading and button spacing for Desktop view in policy overview.
+      - Policy logo and Beta block are now centered.

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -55,12 +55,12 @@ export class US extends Country {
     }
     name = "us"
     properName = "US"
-    beta = true
+    beta = true;
     // Pages to show
-    showPolicy = true
-    showPopulationImpact = true
-    showHousehold = true
-    showEarningsVariation = true
+    showPolicy = true;
+    showPopulationImpact = true;
+    showHousehold = true;
+    showEarningsVariation = true;
     showWealth = false;
     showFAQ = true
     // Vanity URLs

--- a/policyengine-client/src/policyengine/general/navigationButton.jsx
+++ b/policyengine-client/src/policyengine/general/navigationButton.jsx
@@ -19,7 +19,7 @@ export default function SimulateButton(props) {
 		button = <Link to={url}>{button}</Link>;
 	}
 	return (
-		<div style={{ marginBottom: 20 }}>
+		<div style={{ marginBottom: 20, width: "90%", paddingLeft: "10%"}}>
 			{button}
 		</div>
 	);

--- a/policyengine-client/src/policyengine/header/title.jsx
+++ b/policyengine-client/src/policyengine/header/title.jsx
@@ -34,7 +34,7 @@ export default function Title(props) {
 				<div className="d-flex align-items-center justify-content-center">
 					<PageHeader
 						title={title}
-						style={{ paddingBottom: 8 }}
+						style={{ paddingBottom: 8, padding: 10}}
 						tags={betaTag}
 					/>
 				</div>

--- a/policyengine-client/src/policyengine/header/title.jsx
+++ b/policyengine-client/src/policyengine/header/title.jsx
@@ -34,7 +34,7 @@ export default function Title(props) {
 				<div className="d-flex align-items-center justify-content-center">
 					<PageHeader
 						title={title}
-						style={{ paddingBottom: 8, padding: 10}}
+						style={{ paddingBottom: 8, padding: 10, paddingLeft: 64.54 }}
 						tags={betaTag}
 					/>
 				</div>

--- a/policyengine-client/src/policyengine/pages/policy/overview.jsx
+++ b/policyengine-client/src/policyengine/pages/policy/overview.jsx
@@ -49,10 +49,10 @@ function generateStepFromParameter(parameter, editingReform, country, page) {
 export function OverviewHolder(props) {
 	return (
 		<>
-			<div className="d-block d-lg-none">
+			<div className="d-block d-lg-none" style={{backgroundColor: "rgb(245, 245, 245)", borderRadius: "16px"}}>
 				{props.children}
 			</div>
-			<div className="d-none d-lg-block">
+			<div className="d-none d-lg-block" style={{backgroundColor: "rgb(245, 245, 245)", borderRadius: "16px"}}>
 				{props.children}
 			</div>
 		</>

--- a/policyengine-client/src/policyengine/pages/policy/overview.jsx
+++ b/policyengine-client/src/policyengine/pages/policy/overview.jsx
@@ -52,7 +52,7 @@ export function OverviewHolder(props) {
 			<div className="d-block d-lg-none" style={{backgroundColor: "rgb(245, 245, 245)", borderRadius: "16px"}}>
 				{props.children}
 			</div>
-			<div className="d-none d-lg-block" style={{backgroundColor: "rgb(245, 245, 245)", borderRadius: "16px"}}>
+			<div className="d-none d-lg-block" style={{backgroundColor: "rgb(245, 245, 245)", borderRadius: "16px", height: "100%"}}>
 				{props.children}
 			</div>
 		</>
@@ -105,7 +105,7 @@ export function SharePolicyLinks(props) {
 	const url = policyToURL(`https://policyengine.org/${country.name}/${props.page}`, country.policy);
 	return (
 		<>
-			<Divider><Button style={{marginRight: 20, border: 0}} onClick={() => {navigator.clipboard.writeText(url); message.info("Link copied!");}}><LinkOutlined /></Button><TwitterShareButton style={{marginRight: 20, border: 0}} title="I just simulated a reform to the UK tax and benefit system with @ThePolicyEngine. Check it out or make your own!" url={url}><TwitterOutlined /></TwitterShareButton></Divider>
+			<Divider><Button style={{marginRight: 20, border: 0}} onClick={() => {navigator.clipboard.writeText(url); message.info("Link copied!");}}><LinkOutlined /></Button><TwitterShareButton style={{width: "44px", height: "32px", border: 0, backgroundColor: "white", borderRadius: "16px"}} title="I just simulated a reform to the UK tax and benefit system with @ThePolicyEngine. Check it out or make your own!" url={url}><TwitterOutlined /></TwitterShareButton></Divider>
 		</>
 	);
 }


### PR DESCRIPTION
Fixed #826 

Header logo is now centered on mobile.
- The block containing the logo and Beta is centered. If we want to center only the logo and have the Beta sign offset, please let me know.
- When we turn Beta off, the logo will automatically be centered.


![Screen Shot 2022-08-15 at 3 30 49 PM](https://user-images.githubusercontent.com/88756231/184732167-b4e5b013-0d82-485f-9a6c-4773cdcd996e.png)
![Screen Shot 2022-08-15 at 3 31 21 PM](https://user-images.githubusercontent.com/88756231/184732170-57eeced9-0813-4a76-b90a-fd2a61d6c9b9.png)

