### PR TITLE
Adjusted spacing in state code drop-down

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Adjusted spacing in state code drop-down.

--- a/policyengine-client/src/policyengine/pages/household/variable.jsx
+++ b/policyengine-client/src/policyengine/pages/household/variable.jsx
@@ -29,12 +29,13 @@ function BooleanParameterControl(props) {
 
 function CategoricalParameterControl(props) {
 	return <Select 
-		style={{minWidth: 200, marginLeft: 0, paddingLeft: 0}} 
+		style={{minWidth: 200, marginLeft: 0, paddingLeft: 10, border: "1px solid black", borderRadius: 20}} 
 		showSearch 
 		placeholder={props.metadata.defaultValue.value} 
 		value={props.metadata.value}
 		disabled={props.metadata.disabled}
 		bordered={false}
+		dropdownStyle={{borderRadius:20}}
 		onSelect={props.onChange}>
 		{props.metadata.possibleValues.map(value => (
 			<Option 


### PR DESCRIPTION
Fixes #757

- Spacing has been adjusted for both the selected and drop-down menu in State Codes.
- A border has been added around the selected state to improve visability.