### PR TITLE
Padding added to support scrolling

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Added bottom padding to the Policy and Your Household menu.

--- a/policyengine-client/src/policyengine/pages/household/menu.jsx
+++ b/policyengine-client/src/policyengine/pages/household/menu.jsx
@@ -31,7 +31,7 @@ export default function Menu(props) {
 			mode="inline"
 			defaultOpenKeys={country.defaultOpenVariableGroups}
 			defaultSelectedKeys={[country.defaultSelectedVariableGroup]}
-			style={{fontSize: 18}}
+			style={{fontSize: 18, paddingBottom: 20}}
 		>
 			{addMenuEntry(country.inputVariableHierarchy, "")}
 		</AntMenu>

--- a/policyengine-client/src/policyengine/pages/policy/menu.jsx
+++ b/policyengine-client/src/policyengine/pages/policy/menu.jsx
@@ -60,6 +60,7 @@ export default function Menu(props) {
       mode="inline"
       defaultOpenKeys={country.defaultOpenParameterGroups}
       defaultSelectedKeys={[country.defaultSelectedParameterGroup]}
+      style={{ paddingBottom: 20 }}
     >
       {addMenuEntry(country.parameterHierarchy, "")}
     </AntMenu>

--- a/policyengine-client/src/policyengine/pages/policy/overview.jsx
+++ b/policyengine-client/src/policyengine/pages/policy/overview.jsx
@@ -52,10 +52,10 @@ function generateStepFromParameter(parameter, editingReform, country, page) {
 export function OverviewHolder(props) {
 	return (
 		<>
-			<div className="d-block d-lg-none" style={{backgroundColor: "rgb(245, 245, 245)"}}>
+			<div className="d-block d-lg-none" style={{backgroundColor: "#fafafa"}}>
 				{props.children}
 			</div>
-			<div className="d-none d-lg-block" style={{backgroundColor: "rgb(245, 245, 245)", height: "100%"}}>
+			<div className="d-none d-lg-block" style={{backgroundColor: "#fafafa", height: "100%"}}>
 				{props.children}
 			</div>
 		</>


### PR DESCRIPTION
Update to #471 .

Policy and Your Household menus have been given padding to support a better UX when scrolling.

- Prior to this PR, if the viewheight was smaller than the menu height, the last child in the menu was cut off by the footer (image 1).
- Now, the entire column has been given bottom padding to facilite the last child (image 2).
- Policy Overview and menus now have the same hex color (image 3).
