### PR TITLE
Centering pagination in policy cart

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Centering pagination in policy cart.

--- a/policyengine-client/src/policyengine/pages/policy/overview.jsx
+++ b/policyengine-client/src/policyengine/pages/policy/overview.jsx
@@ -91,9 +91,10 @@ export function PolicyOverview(props) {
 								(plan.length > pageSize) && <Pagination 
 									pageSize={pageSize} 
 									defaultCurrent={page} 
-									simple 
+									controlled
 									onChange={setPage} 
 									total={plan.length} 
+									style={{ textAlign: "center" }}
 								/>
 							}
 					</> :


### PR DESCRIPTION
Fixes #784 

Style for pagination in the policy cart was changed from "Simple" to "Controlled." This change allows for easier centering and navigation to the different pages.

The number of pages that appear are determined by the number of items in the cart and the width of the policy cart. Pagination iteself does not overflow the policy cart container. 