### PR TITLE
Fix Scottish rates policy menu crashing the app

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Scottish rates menu broke.

--- a/policyengine-client/src/countries/uk/uk.jsx
+++ b/policyengine-client/src/countries/uk/uk.jsx
@@ -119,7 +119,6 @@ export class UK extends Country {
           ],
           "Scottish rates": [
             "scottish_starter_rate",
-            "scottish_starter_threshold",
             "scottish_basic_rate",
             "scottish_basic_threshold",
             "scottish_intermediate_rate",


### PR DESCRIPTION
Fixes #939