### PR TITLE
Fix region-specific bug

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+    - A bug causing region-specific simulations to be erroneously cached as the general baseline.

--- a/policyengine/country/country.py
+++ b/policyengine/country/country.py
@@ -124,18 +124,23 @@ class PolicyEngineCountry:
         )
 
     def create_microsimulations(
-        self, parameters: dict, force_refresh_baseline: bool = False
+        self,
+        parameters: dict,
+        force_refresh_baseline: bool = False,
+        do_not_cache: bool = False,
     ):
         """Generate a microsimulations from PolicyEngine parameters.
 
         Args:
             parameters (dict): The PolicyEngine parameters.
             force_refresh_baseline (bool): If True, force a refresh of the baseline microsimulation.
+            do_not_cache (bool): If True, do not cache the microsimulation.
         """
         policy_reform = self.create_reform(parameters)
         if (
             not policy_reform.edits_baseline
             and self.baseline_microsimulation is None
+            and not do_not_cache
         ):
             try:
                 baseline = (

--- a/policyengine/country/uk/uk.py
+++ b/policyengine/country/uk/uk.py
@@ -22,7 +22,9 @@ class UK(PolicyEngineCountry):
         filtered_country = parameters.get("baseline_country_specific")
         if filtered_country is not None:
             baseline, reformed = super().create_microsimulations(
-                parameters, force_refresh_baseline=True
+                parameters,
+                force_refresh_baseline=True,
+                do_not_cache=True,
             )
             # Specific country selected: filter out other countries.
             household_weights = baseline.calc("household_weight")

--- a/policyengine/country/us/us.py
+++ b/policyengine/country/us/us.py
@@ -34,7 +34,7 @@ class US(PolicyEngineCountry):
                 )
         else:
             baseline, reformed = super().create_microsimulations(
-                parameters, force_refresh_baseline=True
+                parameters, force_refresh_baseline=True, do_not_cache=True
             )
             # Specific State selected: filter out other States.
             household_weights = baseline.calc("household_weight")


### PR DESCRIPTION
I was able to reproduce the error on the UK system, by running a NI-specific simulation and then a UK-specific simulation. The £1tr net cost is because it erroneously saved the NI baseline as the UK baseline, and the different between total net income between the UK and NI is roughly £1tr. Fixes #903