### PR TITLE
Display new BI parameters: AGI limit and dollar-defined phase-out range

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Basic income parameters for AGI limit and dollar-defined phase-out range.

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -475,9 +475,15 @@ export class US extends Country {
                         "senior_bi_age",
                         "senior_bi",
                     ],
-                    "Phase-outs": [
-                        "bi_phase_out_rate",
+                    "Phase-out": [
                         "bi_phase_out_threshold",
+                        "bi_phase_out_by_rate",
+                        "bi_phase_out_rate",
+                        "bi_phase_out_end",
+                    ],
+                    "Eligibility": [
+                        "bi_agi_limit_in_effect",
+                        "bi_agi_limit_amount",
                     ],
                 },
                 "Flat tax": [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "OpenFisca-Core",
         "OpenFisca-Tools>=0.12.0",
         "OpenFisca-UK==0.29.0",
-        "OpenFisca-US==0.132.0",
+        "OpenFisca-US==0.135.1",
         "pandas",
         "plotly",
         "pytest",


### PR DESCRIPTION
Fixes #957 and fixes #961

Locally, the How earnings affect you chart spins forever when toggling either the AGI limit or the dollar-defined phase-out range, but everything else works right so going to merge this and debug that separately.