### PR TITLE
Add axis handling for `/calculate`

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Axis handling for /calculate endpoints.

--- a/policyengine/country/country.py
+++ b/policyengine/country/country.py
@@ -271,21 +271,28 @@ class PolicyEngineCountry:
             variable = system.get_variable(variable_name)
             result = simulation.calculate(variable_name, period)
             population = simulation.get_population(entity_plural)
-            entity_index = population.get_index(entity_id)
+            try:
+                entity_index = population.get_index(entity_id)
 
-            if variable.value_type == Enum:
-                entity_result = result.decode()[entity_index].name
-            elif variable.value_type == float:
-                entity_result = float(str(result[entity_index]))
-            elif variable.value_type == str:
-                entity_result = str(result[entity_index])
-            else:
-                entity_result = result.tolist()[entity_index]
+                if variable.value_type == Enum:
+                    entity_result = result.decode()[entity_index].name
+                elif variable.value_type == float:
+                    entity_result = float(str(result[entity_index]))
+                elif variable.value_type == str:
+                    entity_result = str(result[entity_index])
+                else:
+                    entity_result = result.tolist()[entity_index]
 
-            # Bug fix, unclear of the root cause
+                # Bug fix, unclear of the root cause
 
-            if isinstance(entity_result, list) and len(entity_result) > 2_000:
-                entity_result = {period: entity_result[-1]}
+                if (
+                    isinstance(entity_result, list)
+                    and len(entity_result) > 2_000
+                ):
+                    entity_result = {period: entity_result[-1]}
+            except:
+                # In cases of axes, the entity ID won't resolve (e.g. you requested a value for person, but instead there's on person1, person2, ...)
+                entity_result = list(result.astype(float))
 
             dpath.util.new(computation_results, path, entity_result)
 


### PR DESCRIPTION
Ensures that situations defined with [axes](https://openfisca.org/doc/simulate/replicate-simulation-inputs.html) work on `/calculate`.