### PR TITLE
Add US basic income taxability

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - US basic income taxability switch.

--- a/policyengine-client/src/countries/us/us.jsx
+++ b/policyengine-client/src/countries/us/us.jsx
@@ -638,6 +638,7 @@ export class US extends Country {
                         "bi_phase_out_by_rate",
                         "bi_phase_out_rate",
                         "bi_phase_out_end",
+                        "bi_taxability",
                     ],
                     "Eligibility": [
                         "bi_agi_limit_in_effect",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "microdf_python",
         "numpy",
         "OpenFisca-Core",
-        "OpenFisca-Tools>=0.13.3",
+        "OpenFisca-Tools>=0.13.8",
         "OpenFisca-UK==0.30.1",
         "OpenFisca-US==0.155.0",
         "pandas",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "OpenFisca-Core",
         "OpenFisca-Tools>=0.13.3",
         "OpenFisca-UK==0.30.1",
-        "OpenFisca-US==0.148.0",
+        "OpenFisca-US==0.155.0",
         "pandas",
         "plotly",
         "pytest",


### PR DESCRIPTION
Fixes #1006

After bumping the requirements and running `make install`, the server is throwing this error after computing the population impact:
>  [2022-09-13T12:47:56.817818] event: task_error endpoint: population_reform error: "Unable to open object (object 'marital_unit_id' doesn't exist)" full_trace: Traceback (most recent call last):