### PR TITLE
Word wrap to menu items

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Word wrap to menu items.

--- a/policyengine-client/src/policyengine/pages/policy/menu.jsx
+++ b/policyengine-client/src/policyengine/pages/policy/menu.jsx
@@ -33,7 +33,11 @@ export default function Menu(props) {
       if (Array.isArray(parameter[child])) {
         children.push(
           <AntMenu.Item icon={logo} key={name}>
-            {logo ? <div style={{ paddingLeft: 10 }}>{child}</div> : child}
+            {
+              logo 
+              ? <div style={{ paddingLeft: 10 }}>{child}</div> 
+              : <div style={{lineHeight: "20px", whiteSpace: "normal", height: "auto"}}>{child}</div>
+            }
           </AntMenu.Item>
         );
       } else {
@@ -42,7 +46,9 @@ export default function Menu(props) {
             icon={logo}
             key={name}
             title={
-              logo ? <div style={{ paddingLeft: 10 }}>{child}</div> : child
+              logo 
+              ? <div style={{ paddingLeft: 10 }}>{child}</div> 
+              : <div style={{lineHeight: "20px", whiteSpace: "normal", height: "auto"}}>{child}</div>
             }
           >
             {addMenuEntry(parameter[child], name)}


### PR DESCRIPTION
Fixes #973.

- Menu items now word wrap when their name is cut short by the right border.
- This patch is applied to all levels in the policy menu.

![Image 1](https://user-images.githubusercontent.com/88756231/191632510-88b7952a-8568-4c40-b8b3-80f0ecc5af93.png)
![Image 2](https://user-images.githubusercontent.com/88756231/191632512-f7cd7025-76f0-49a2-b808-340d4479440b.png)