### PR TITLE
Fix US pages

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - US pages.

--- a/policyengine-client/src/countries/country.jsx
+++ b/policyengine-client/src/countries/country.jsx
@@ -11,6 +11,7 @@ export default class Country {
     editingReform = true;
     year = 2022
     showDatePicker = false;
+    parameterRenames = {};
 
     updatePolicy(name, value) {
         // Update a parameter - validate, then update the state


### PR DESCRIPTION
This change wasn't caught because usually I avoid staging changes to `country.jsx`: in this case, there was a one-liner by the last PR that was needed to avoid breaking a page.