### PR TITLE
Mobile PolicyEngine logo is now centered in both countries

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - PolicyEngine logo adjustment

--- a/policyengine-client/src/policyengine/header/title.jsx
+++ b/policyengine-client/src/policyengine/header/title.jsx
@@ -34,8 +34,12 @@ export default function Title(props) {
 				<div className="d-flex align-items-center justify-content-center">
 					<PageHeader
 						title={title}
-						style={{ paddingBottom: 8, padding: 10, paddingLeft: 64.54 }}
 						tags={betaTag}
+						style={{ 
+							paddingBottom: 8, 
+							padding: 10,
+							paddingLeft: betaTag ? 54 : 0,
+						}}
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
Fixes #946.

- Top PolicyEngine logo is now centered in both US and UK.
