### PR TITLE
Policy Cart items are now centered on desktop

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Center policy cart items on Desktop.

--- a/policyengine-client/src/policyengine/pages/policy/overview.jsx
+++ b/policyengine-client/src/policyengine/pages/policy/overview.jsx
@@ -55,7 +55,7 @@ export function OverviewHolder(props) {
 			<div className="d-block d-lg-none" style={{backgroundColor: "#fafafa"}}>
 				{props.children}
 			</div>
-			<div className="d-none d-lg-block" style={{backgroundColor: "#fafafa", height: "100%"}}>
+			<div className="d-none d-lg-block" style={{backgroundColor: "#fafafa", height: "100%", textAlign: "center"}}>
 				{props.children}
 			</div>
 		</>


### PR DESCRIPTION
Fixes #1034.

Policy Cart items are now centered on Desktop.