### PR TITLE
Add Text to Radio Buttons

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+      - Add text to radio buttons

--- a/policyengine-client/src/policyengine/pages/household/variable.jsx
+++ b/policyengine-client/src/policyengine/pages/household/variable.jsx
@@ -24,6 +24,8 @@ function BooleanParameterControl(props) {
 	return <Switch
 		onChange={props.onChange}
 		checked={props.metadata.value}
+		checkedChildren="True"
+		unCheckedChildren="False"
 	/>
 }
 


### PR DESCRIPTION
Currently waiting on what to write inside the radio buttons. Due to the variety of prompts, True/False may not be the most optimal solution.

Also, we can make a similar change to the switch buttons when users are searching through policies.

![Screen Shot 2022-10-06 at 10 30 54 AM](https://user-images.githubusercontent.com/88756231/194380993-df9f18dd-44a8-4d09-acdc-977703209af7.png)
![Screen Shot 2022-10-06 at 10 31 06 AM](https://user-images.githubusercontent.com/88756231/194380996-e9cbe0d4-a17c-4a27-81d0-ceb8566baaeb.png)
