### PR TITLE
Adjusted drop-down menus to text-width maximum

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: minor
   changes:
     added:
-      - Removed "square look from LinkedIn and Facebook icon.
+      - Adjusted drop-down menus to text-width maximum.

--- a/policyengine-client/src/policyengine/pages/policy/parameter/parameter.jsx
+++ b/policyengine-client/src/policyengine/pages/policy/parameter/parameter.jsx
@@ -92,7 +92,7 @@ function BreakdownParameterControl(props) {
 		});
 		let possibleKeys = [...new Set(possibleValues.map(value => value[0]))];
 		dropDowns.push(
-			<Select key={i} defaultValue={possibleKeys[0]} style={{marginLeft: 0, paddingLeft: 0}} bordered={false} onChange={target => {
+			<Select key={i} defaultValue={possibleKeys[0]} dropdownMatchSelectWidth={false} style={{marginLeft: 0, paddingLeft: 0}} bordered={false} onChange={target => {
 				let selectedCopy = [...selected];
 				selectedCopy[i] = target;
 				setSelected(selectedCopy);


### PR DESCRIPTION
Fixes #604 

- Dropdown menus through the app now show all options without being cutoff.
- This patch is effective in both desktop and mobile viewports.

![Screen Shot 2022-11-03 at 11 19 59 AM](https://user-images.githubusercontent.com/88756231/199804470-baa4633d-e572-48df-9c0f-8cb437bc1924.png)
![Screen Shot 2022-11-03 at 11 20 14 AM](https://user-images.githubusercontent.com/88756231/199804474-f692a527-ff54-4061-a17f-e31aeab3d87f.png)
