### PR TITLE
right-align numbers in net income table

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: minor
   changes:
     added:
-      - Adjusted drop-down menus to text-width maximum.
+      - Right-align numbers in net income table.

--- a/policyengine-client/src/policyengine/pages/household/accountingTable.jsx
+++ b/policyengine-client/src/policyengine/pages/household/accountingTable.jsx
@@ -168,19 +168,22 @@ function VariableTable(props) {
             dataIndex: "baseline",
             key: "baseline",
             width: 10,
-            align: "center",
+            align: "right",
+            
         }, {
             title: "Reform",
             dataIndex: "reform",
             key: "reform",
             width: 10,
-            align: "center",
+            align: "right",
         }, {
             title: "Change",
             dataIndex: "change",
             key: "change",
             width: 10,
-            align: "center",
+            align: "right",
+        }, {
+            width: 17,
         }];
     } else {
         columns = [{
@@ -192,8 +195,10 @@ function VariableTable(props) {
             title: "Value",
             dataIndex: "baseline",
             key: "baseline",
-            align: "center",
+            align: "right",
             width: 80,
+        }, {
+            width: 8,
         }]
     }
     const data = generateTableData(props.variable, country, 0, true);


### PR DESCRIPTION
Fixes #609 

- Numbers on the net-income table are now aligned to the right. 
- An extra column was added to the end of the table to provide padding and preserve the upper-right border-radius.


![Screen Shot 2022-11-07 at 11 09 20 AM](https://user-images.githubusercontent.com/88756231/200394877-4a6b650b-7fe1-4181-bb4b-90e190dd2085.png)
![Screen Shot 2022-11-07 at 11 09 41 AM](https://user-images.githubusercontent.com/88756231/200394878-ed753b25-0a5e-4b77-a1d8-df87c84be84c.png)
